### PR TITLE
Bash completion script fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ clean:
 
 compile:
 	go mod tidy
-	GOOS=linux GOARCH=arm go build -ldflags "-s -w" -o ./dogo-linux-arm .
-	GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o ./dogo-linux-amd64 .
-	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o ./dogo-windows-amd64 .
-	GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o ./dogo-macos-amd64 .
+	GOOS=linux GOARCH=arm go build -ldflags "-s -w" -o bin/dogo-linux-arm .
+	GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o bin/dogo-linux-amd64 .
+	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o bin/dogo-windows-amd64 .
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o bin/dogo-macos-amd64 .
 
 all: clean compile

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # `dogo` 
 docker command line helper with autocomplete written in [Go](https://go.dev/) and [cobra](https://github.com/spf13/cobra)
 
+## Install
+
+```shell
+go install github.com/XotoX1337/dogo@latest
+```
+
 ## Usage 
 ```shell
 Usage:
@@ -12,12 +18,12 @@ Available Commands:
   help        Help about any command
   list        list all containers & services
   remove      remove one or many containers
-  ssh         connect to a running container
+  shell       connect to a running container
   start       start one or many containers
   stop        stop one or many containers
 ```
 ## Examples
-    dogo ssh yourContainer
+    dogo shell yourContainer
     dogo start firstContainer secondContainer ...
 
 ## Completion

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © 2022 Frederic Leist <frederic.leist@gmail.com>
 */
 package cmd
 
@@ -56,14 +56,15 @@ func getWriter(terminal string, cmd *cobra.Command) io.Writer {
 		customDest, _ := cmd.Flags().GetString("destination")
 		homeDir, _ := os.UserHomeDir()
 		const filename string = "dogo-completion.sh"
-		dest := filepath.Join(homeDir, filename)
+		dest := filepath.Join(homeDir, ".bash_completion.d")
 		if customDest != "" {
-			dest = filepath.Join(homeDir, filename)
+			dest = filepath.Join(customDest)
 		}
 		if _, err := os.Stat(dest); os.IsNotExist(err) {
 			os.MkdirAll(dest, 0644)
 		}
-		file, err := os.OpenFile(dest, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+		abs := filepath.Join(dest, filename)
+		file, err := os.OpenFile(abs, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 		if err != nil {
 			log.Warn("could not write completion script")
 			log.Fatal(err.Error())

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © 2022 Frederic Leist <frederic.leist@gmail.com>
 */
 package cmd
 

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -62,7 +62,7 @@ func rebuild(args []string) {
 func rebuildServices(config string, services []string) {
 
 	log.Info(fmt.Sprintf("rebuilding %v...\n", services))
-	command := exec.Command("bash", "-c", "docker compose -f "+config+" build --quiet "+strings.Join(services, " "))
+	command := exec.Command("sh", "-c", "docker compose -f "+config+" build --quiet "+strings.Join(services, " "))
 	command.Stderr = os.Stderr
 	err := command.Run()
 	if err != nil {
@@ -74,7 +74,7 @@ func rebuildServices(config string, services []string) {
 
 func recreateServices(config string, services []string) {
 	fmt.Printf("recreating %v...\n", services)
-	command := exec.Command("bash", "-c", "docker compose -f "+config+" create "+strings.Join(services, " "))
+	command := exec.Command("sh", "-c", "docker compose -f "+config+" create "+strings.Join(services, " "))
 	command.Stderr = os.Stderr
 	err := command.Run()
 	if err != nil {

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © 2022 Frederic Leist <frederic.leist@gmail.com>
 */
 package cmd
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © 2022 Frederic Leist <frederic.leist@gmail.com>
 */
 package cmd
 

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// shellCmd represents the ssh command
+// shellCmd represents the shell command
 var shellCmd = &cobra.Command{
 	Use:   "shell",
 	Short: "use shell of a running container",

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © 2022 Frederic Leist <frederic.leist@gmail.com>
 */
 package cmd
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © 2022 Frederic Leist <frederic.leist@gmail.com>
 */
 package cmd
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/XotoX1337/dogo/log"
 	"github.com/XotoX1337/dogo/lookup"
-	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/spf13/cobra"
 )
 
@@ -36,7 +35,7 @@ func stopContainers(containers []string) {
 	cli := lookup.Client()
 	for _, container := range containers {
 		log.Info(fmt.Sprintf("stopping %s...", container))
-		err := cli.ContainerStop(context.Background(), container, containertypes.StopOptions{})
+		err := cli.ContainerStop(context.Background(), container, nil)
 		if err != nil {
 			log.Warn(fmt.Sprintf("could not stop container %s", container))
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/XotoX1337/dogo
 go 1.19
 
 require (
-	github.com/docker/docker v23.0.2+incompatible
+	github.com/docker/docker v20.10.23+incompatible
 	github.com/jedib0t/go-pretty/v6 v6.4.6
 	github.com/spf13/cobra v1.6.1
 )
@@ -22,6 +22,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v23.0.2+incompatible h1:q81C2qQ/EhPm8COZMUGOQYh4qLv4Xu6CXELJ3WK/mlU=
-github.com/docker/docker v23.0.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.23+incompatible h1:1ZQUUYAdh+oylOT85aA2ZcfRp22jmLhoaEcVEfK8dyA=
+github.com/docker/docker v20.10.23+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -44,12 +44,15 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -74,6 +77,7 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © 2022 Frederic Leist <frederic.leist@gmail.com>
 */
 package main
 


### PR DESCRIPTION
- If the folders for the autocomplete script do not exist, they are now created
- Fixed copyright in all files
- downgraded github.com/docker/docker to v20.10.23+incompatible
- changed bash to sh in rebuild.go
- updated README.md