### PR TITLE
bugfix log package

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -14,31 +14,29 @@ var prefixMap = map[int]string{
 	constants.LOG_LEVEL_FATAL: "FATAL: ",
 }
 
-func Log(level int, message string, format ...any) {
+func log(level int, message string, format ...any) {
 	fmt.Printf(
 		"%s %s\n",
 		prefixMap[level],
 		fmt.Sprintf(message, format...),
 	)
-
 	if level == constants.LOG_LEVEL_FATAL {
 		os.Exit(1)
 	}
 }
 
 func Debug(message string, format ...any) {
-
-	Log(constants.LOG_LEVEL_DEBUG, message)
+	log(constants.LOG_LEVEL_DEBUG, message, format...)
 }
 
 func Info(message string, format ...any) {
-	Log(constants.LOG_LEVEL_INFO, message)
+	log(constants.LOG_LEVEL_INFO, message, format...)
 }
 
 func Warn(message string, format ...any) {
-	Log(constants.LOG_LEVEL_WARN, message)
+	log(constants.LOG_LEVEL_WARN, message, format...)
 }
 
 func Fatal(message string, format ...any) {
-	Log(constants.LOG_LEVEL_FATAL, message)
+	log(constants.LOG_LEVEL_FATAL, message, format...)
 }


### PR DESCRIPTION
* fixed formatting of variables passed to methods ** log.Debug, log.Info, log.Warn, log.Fatal
* changed visibility of method log of package log from public to private